### PR TITLE
Supervisor removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,4 +64,4 @@ COPY deploy-script.sh /usr/local/tomcat/bin/
 RUN chmod +x /usr/local/tomcat/bin/deploy-script.sh
 
 # call the deploy-script.sh (which copies in jdbc drivers also starts the tomcat server)
-CMD ["sh", "-c", "/usr/local/tomcat/bin/deploy-script.sh"]
+CMD ["/usr/local/tomcat/bin/catalina.sh", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,10 @@ ARG WEBAPI_WAR=WebAPI-1.0.0.war
 # add a Tomcat server management web UI 'admin' user with default 'abc123' password!
 COPY tomcat-users.xml /usr/local/tomcat/conf/
 
-# install linux utilities and supervisor daemon
+# install linux utilities
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     unzip \
-    supervisor \
     build-essential \
     nodejs \
     curl \
@@ -55,17 +54,14 @@ WORKDIR /usr/local/tomcat/webapps/atlas
 RUN npm run build
 
 # create directories for optional jdbc drivers and the log files
-RUN mkdir -p /tmp/drivers /var/log/supervisor
-
-# install supervisord configuration file
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+RUN mkdir -p /tmp/drivers
 
 # install Atlas local configuration file
 COPY config-local.js /usr/local/tomcat/webapps/atlas/js/
 
-# install the bash shell deploy script that supervisord will run whenever the container is started
+# install the bash shell deploy script will run when the container is started
 COPY deploy-script.sh /usr/local/tomcat/bin/
 RUN chmod +x /usr/local/tomcat/bin/deploy-script.sh
 
-# run supervisord to execute the deploy script (which also starts the tomcat server)
-CMD ["/usr/bin/supervisord"]
+# call the deploy-script.sh (which copies in jdbc drivers also starts the tomcat server)
+CMD ["/usr/local/tomcat/bin/deploy-script.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,4 +64,4 @@ COPY deploy-script.sh /usr/local/tomcat/bin/
 RUN chmod +x /usr/local/tomcat/bin/deploy-script.sh
 
 # call the deploy-script.sh (which copies in jdbc drivers also starts the tomcat server)
-CMD ["/usr/local/tomcat/bin/deploy-script.sh"]
+CMD ["sh", "-c", "/usr/local/tomcat/bin/deploy-script.sh"]

--- a/deploy-script.sh
+++ b/deploy-script.sh
@@ -1,6 +1,3 @@
-# update the Penelope configuration URL of the WebAPI
-perl -i -pe "BEGIN{undef $/;} s|http://localhost:8080|"$WEBAPI_URL"|g" /usr/local/tomcat/webapps/penelope/web/js/app.js
-
 # load any jdbc drivers in the docker host volume mapped directory into the tomcat library
 cp /tmp/drivers/*.jar /usr/local/tomcat/lib
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,12 @@ services:
 
   broadsea-webtools:
     build: .
-    image: scivm/broadsea-webtools
+    image: ohdsi/broadsea-webtools
     ports:
       - "8080:8080"
     volumes:
      - .:/tmp/drivers/:ro
-       # - ./config-local.js:/usr/local/tomcat/webapps/atlas/js/config-local.js:ro
+     - ./config-local.js:/usr/local/tomcat/webapps/atlas/js/config-local.js:ro
     environment:
       - datasource_driverClassName=org.postgresql.Driver
       - datasource_url=jdbc:postgresql://192.168.1.8:5432/secret-database-name

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
      - .:/tmp/drivers/:ro
      - ./config-local.js:/usr/local/tomcat/webapps/atlas/js/config-local.js:ro
     environment:
-      - WEBAPI_URL=http://192.168.1.8:8080
       - datasource_driverClassName=org.postgresql.Driver
       - datasource_url=jdbc:postgresql://192.168.1.8:5432/secret-database-name
       - datasource_username=secret-user-name

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,12 @@ services:
 
   broadsea-webtools:
     build: .
-    image: ohdsi/broadsea-webtools
+    image: scivm/broadsea-webtools
     ports:
       - "8080:8080"
     volumes:
      - .:/tmp/drivers/:ro
-     - ./config-local.js:/usr/local/tomcat/webapps/atlas/js/config-local.js:ro
+       # - ./config-local.js:/usr/local/tomcat/webapps/atlas/js/config-local.js:ro
     environment:
       - datasource_driverClassName=org.postgresql.Driver
       - datasource_url=jdbc:postgresql://192.168.1.8:5432/secret-database-name

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,5 +1,0 @@
-[supervisord]
-nodaemon=true
-
-[program:deploy-script]
-command=bash -c /usr/local/tomcat/bin/deploy-script.sh


### PR DESCRIPTION
Here is a pull request for discussion.  I tried to make as few changes as possible.   I did have one issue with the deploy-script.sh so I am currently using:

`CMD ["/usr/local/tomcat/bin/catalina.sh", "run"]`
which loses the copying of the database drivers from a tmp directory.   I had tried to run deploy-script.sh directly but then WebAPI was not able to read in environment variables.   Need to check it more. 

Using the "run" command and no supervisor causes all logs to do to stdout.   This is helpful when running docker in kubernetes as the logs are centrally logged. 

tomcat is still running as root and I would like to change it to run as a non root user.   This would typically be a requirement for running in a secure kubernetes cluster since the pod security policy would prevent containers running as root.

WEBAPI_URL appears to be legacy for a penalope application?

I did not see these?
```
version: "3.7"
services:
web:
image: alpine:latest
init: true
```