### PR TITLE
Added ability to set webapi url in config-local.js via env var

### DIFF
--- a/deploy-script.sh
+++ b/deploy-script.sh
@@ -1,5 +1,14 @@
-# update the Penelope configuration URL of the WebAPI
-perl -i -pe "BEGIN{undef $/;} s|http://localhost:8080|"$WEBAPI_URL"|g" /usr/local/tomcat/webapps/penelope/web/js/app.js
+#!/bin/bash
+
+# make sure the WebAPI URL ends with a slash
+if [[ "$WEBAPI_URL" != */ ]]; then
+    WEBAPI_URL="$WEBAPI_URL/"
+fi
+
+# if set, replace the webapi URL in the config file with the one in the WEBAPI_URL env var
+if [ -v WEBAPI_URL ]; then
+    sed -i "s,http://localhost:8080/WebAPI/,$WEBAPI_URL,g" /usr/local/tomcat/webapps/atlas/js/config-local.js
+fi
 
 # load any jdbc drivers in the docker host volume mapped directory into the tomcat library
 cp /tmp/drivers/*.jar /usr/local/tomcat/lib

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - "8080:8080"
     volumes:
      - .:/tmp/drivers/:ro
-     - ./config-local.js:/usr/local/tomcat/webapps/atlas/js/config-local.js:ro
     environment:
       - WEBAPI_URL=http://192.168.1.8:8080
       - datasource_driverClassName=org.postgresql.Driver


### PR DESCRIPTION
This removes the need to mount the config-local.js into the container and set the WebAPI URL there, thus making the configuration easier.

Closes #4 